### PR TITLE
Fix for loop bug with Redis down and fix for uncaught errors in spawned worker's redis

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -265,10 +265,12 @@ JobQueue.prototype.shutdown = function(callback) {
 
   var pend = new Pend();
   pend.go(function(cb) {
-    self.redisClient.quit(function(err, result) {
-      if (err) {
-        self.emit('error', err);
-      }
+    self.redisClient.quit(function(err) {
+        /* We want to kill this instance of the redis client, so at at this point we
+         * are not interested in what connection errors Redis comes up with.
+         */
+
+        self.redisClient.end();
       cb();
     });
   });

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -100,7 +100,6 @@ Worker.prototype.start = function() {
   this.shuttingDown = false;
   this.pend = new Pend();
   this.blockingRedisClients = [];
-  this.redisClientStatus = [];
   for (var i = 0; i < this.workerCount; i += 1) {
     this.spawnWorker();
   }
@@ -123,12 +122,15 @@ Worker.prototype.spawnWorker = function() {
   var self = this;
 
   // create new client because blpop blocks the connection
-  var redisClient = createRedisClient(self.redisConfig);
+  var workerInternalRedisClient = createRedisClient(self.redisConfig);
   var clientObj = {
-    redisClient: redisClient,
+    redisClient: workerInternalRedisClient,
     blocking: false,
   };
   self.blockingRedisClients.push(clientObj);
+
+  // avoid uncaught errors from the worker internal redis client killing the Node process
+  workerInternalRedisClient.on('error', self.emit.bind(self,'error'));
 
   handleOne();
 
@@ -138,11 +140,13 @@ Worker.prototype.spawnWorker = function() {
   }
 };
 
-Worker.prototype.processOneItem = function(clientObj, cb) {
+Worker.prototype.processOneItem = function(clientObj, nextJob) {
   var self = this;
 
   var redisClient = clientObj.redisClient;
   clientObj.blocking = true;
+
+  // this command will trigger the callback synchronously if the connection is down
   redisClient.send_command('brpoplpush', [self.queueKey, self.processingQueueKey, 0], onResult);
 
   function onResult(err, jobListValue) {
@@ -152,7 +156,10 @@ Worker.prototype.processOneItem = function(clientObj, cb) {
     self.pend.go(function(pendCb) {
       goForIt(err, jobListValue, function() {
         pendCb();
-        cb();
+
+        // allow Node to process the event loop before initiating the next job
+        // this remedies a situation where we create a non-ending (synchronous) loop on connection down
+        process.nextTick(nextJob);
       });
     });
   }


### PR DESCRIPTION
This PR fixes the loop problems mentioned in #5, that is caused by a recursive synchronous function call, by passing the job task on to `nextTick`.

There was also a problem with the internal redis client in each spawned worker emitting errors that were not listened to anywhere. That killed our Node process when Redis disconnected.
